### PR TITLE
migrate backend to nagari account

### DIFF
--- a/src/components/layanan/DomisiliFormNew.tsx
+++ b/src/components/layanan/DomisiliFormNew.tsx
@@ -33,8 +33,8 @@ export default function DomisiliFormNew({ onClose }: DomisiliFormProps) {
     if (!file) return '';
     const data = new FormData();
     data.append('file', file);
-    data.append('upload_preset', 'limokoto-upload');
-    const res = await fetch('https://api.cloudinary.com/v1_1/dehm8moqy/image/upload', {
+    data.append('upload_preset', 'limokoto');
+    const res = await fetch('https://api.cloudinary.com/v1_1/de7gk1as4/image/upload', {
       method: 'POST',
       body: data,
     });

--- a/src/components/layanan/SKTempatTinggalForm.tsx
+++ b/src/components/layanan/SKTempatTinggalForm.tsx
@@ -59,8 +59,8 @@ export default function SKTempatTinggalForm({ onClose }: SKTempatTinggalFormProp
   const uploadToCloudinary = async (file: File): Promise<string> => {
     const data = new FormData();
     data.append('file', file);
-    data.append('upload_preset', 'limokoto-upload');
-    const res = await fetch('https://api.cloudinary.com/v1_1/dehm8moqy/image/upload', {
+    data.append('upload_preset', 'limokoto');
+    const res = await fetch('https://api.cloudinary.com/v1_1/de7gk1as4/image/upload', {
       method: 'POST', body: data
     });
     const json = await res.json();

--- a/src/lib/cloudinaryUpload.ts
+++ b/src/lib/cloudinaryUpload.ts
@@ -3,8 +3,8 @@ export const uploadToCloudinary = async (file: File | null): Promise<string> => 
   if (!file) return '';
   const data = new FormData();
   data.append('file', file);
-  data.append('upload_preset', 'limokoto-upload');
-  const res = await fetch('https://api.cloudinary.com/v1_1/dehm8moqy/image/upload', {
+  data.append('upload_preset', 'limokoto');
+  const res = await fetch('https://api.cloudinary.com/v1_1/de7gk1as4/image/upload', {
     method: 'POST',
     body: data,
   });


### PR DESCRIPTION
## Summary by Sourcery

Migrate Cloudinary uploads to the Nagari account by updating upload presets and URLs

Enhancements:
- Replace upload preset 'limokoto-upload' with 'limokoto' for all image uploads
- Update Cloudinary upload endpoint from dehm8moqy to de7gk1as4 in DomisiliFormNew, SKTempatTinggalForm, and lib/cloudinaryUpload